### PR TITLE
Fix popup cleanup callback being incorrectly called

### DIFF
--- a/frontend/steam.ts
+++ b/frontend/steam.ts
@@ -5,14 +5,30 @@ type SB_AppOverview = NonNullable<
 >;
 
 namespace Steam {
+  // ===== CallbackList ===== //
+
+  export interface CallbackList<Arguments extends unknown[]> {
+    m_vecCallbacks: Array<(...args: Arguments) => void>;
+    Register(callback: (...args: Arguments) => void): {
+      Unregister: () => void;
+    };
+    Dispatch(...args: Arguments): void;
+    ClearAllCallbacks(): void;
+    CountRegistered(): number;
+  }
+
   // ===== PopupManager ===== //
 
   export interface PopupManager {
     GetExistingPopup(name: string): Popup | undefined;
-    AddPopupCreatedCallback(callback: (popup: Popup) => void): void;
-    m_rgPopupCreatedCallbacks: {
-      m_vecCallbacks: Array<(popup: Popup) => void>;
-    };
+    m_rgPopupCreatedCallbacks: CallbackList<[Popup]>;
+    AddPopupCreatedCallback(
+      callback: (popup: Popup) => void,
+    ): ReturnType<this['m_rgPopupCreatedCallbacks']['Register']>;
+    m_rgPopupDestroyedCallbacks: CallbackList<[Popup]>;
+    AddPopupDestroyedCallback(
+      callback: (popup: Popup) => void,
+    ): ReturnType<this['m_rgPopupDestroyedCallbacks']['Register']>;
   }
 
   export const PopupManager: PopupManager = Reflect.get(


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* New Features
  * Added support for new popup types (modal and context menu) for richer interactions.

* Bug Fixes
  * Ensured on-close actions reliably run when popups are destroyed.
  * Creation and destruction callbacks are now properly registered and unregistered for more robust lifecycle handling.
  * Removed unreliable window-unload cleanup to prevent missed cleanup.
  * Improved startup handling of existing popups for more predictable behaviour and stability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->