### PR TITLE
Add example in placeholder of playtime input element

### DIFF
--- a/frontend/components/playtime-input.tsx
+++ b/frontend/components/playtime-input.tsx
@@ -57,6 +57,8 @@ export function PlaytimeInput({ app }: { app: Steam.AppOverview }) {
       </div>
       <div className={SettingsStyles.AsyncBackedInputChildren}>
         <TextField
+          // @ts-expect-error - placeholder is a valid prop but not typed
+          placeholder="e.g. 2h 30m"
           defaultValue={initialPlaytime}
           onChange={(e) => {
             if (e.target.value === '') setPlaytimeMs(0);


### PR DESCRIPTION
Closes #24 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added a placeholder hint (“e.g. 2h 30m”) to the Playtime input field to guide users on the expected time format.
  - Improves ease-of-use by clarifying duration entry without changing how input, validation, or saving works.
  - No behavioural changes to existing flows; the update is purely a UI hint to reduce confusion and improve data entry accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->